### PR TITLE
Feature/update use of pytimber

### DIFF
--- a/bihc/beam.py
+++ b/bihc/beam.py
@@ -20,6 +20,7 @@ provided a beam shape and bunch length.
 
 import math
 import sys
+import time
 
 import numpy as np
 from scipy.constants import c, e
@@ -115,10 +116,11 @@ class Beam(Impedance, Power, Plot):
         fmax=2e9,
         exp=2.5,
         verbose=False,
+        spark=None,
     ):
         self.M = M  # Default max numebr of buckets
         self.A_GLOBAL = A
-        self.BUNCH_LENGTH_GLOBAL = bunchLength / 4  # Bunch lenght (sigma) [s]
+        self.BUNCH_LENGTH_GLOBAL = bunchLength / 4  # Bunch length (sigma) [s]
 
         self.PHI_GLOBAL = phi
         self.realMachineLength = realMachineLength
@@ -212,7 +214,7 @@ class Beam(Impedance, Power, Plot):
         # Computes the beam longitudinal profile
         if fillNumber > 0:
             # if user specifies a fill number, data is extracted from timber
-            self.setBeamFromFillNumber(fillNumber, fillMode, beamNumber)
+            self.setBeamFromFillNumber(fillNumber, fillMode, beamNumber, spark=spark)
         elif sum(self._fillingScheme) > 0:
             # if the array is not all False values
             self.setCustomBeamWithFillingScheme()
@@ -629,7 +631,8 @@ class Beam(Impedance, Power, Plot):
         self.profile_1_bunch = profile_1_bunch
         self.longitudinalProfile = [t, s]
 
-    def setBeamFromFillNumber(self, fillNumber, fillMode="FLATTOP", beamNumber=1):
+    def setBeamFromFillNumber(self, fillNumber, fillMode="FLATTOP",
+                              beamNumber=1, spark=None):
         """Set beam from fill number
 
         Retrieves beam fill information from Timber provided a fill Number
@@ -669,7 +672,12 @@ class Beam(Impedance, Power, Plot):
             + "! Warning: This method only works on SWAN for the moment"
             + "\x1b[0m"
         )
-        db = pytimber.LoggingDB()
+        if spark is not None:
+            db = pytimber.LoggingDB(spark_session=spark)
+        else:
+            # without spark, the older version of pytimber may still work
+            db = pytimber.LoggingDB()
+
         bunchLengths = "LHC.BQM.B" + str(beamNumber) + ":BUNCH_LENGTHS"
         filledBuckets = "LHC.BQM.B" + str(beamNumber) + ":FILLED_BUCKETS"
 
@@ -686,9 +694,11 @@ class Beam(Impedance, Power, Plot):
                 "Mode selected: ",
                 self.fillMode,
                 "starts at: ",
-                pytimber.dumpdate(t1),
+                time.strftime("%Y-%m-%d %H:%M:%S.SSS",time.localtime(t1)
+                    ).replace("SSS","%03d" % ((t1-np.floor(t1))*1000)),
                 "ends at",
-                pytimber.dumpdate(t2),
+                time.strftime("%Y-%m-%d %H:%M:%S.SSS",time.localtime(t2)
+                    ).replace("SSS","%03d" % ((t2-np.floor(t2))*1000)),
             )
 
         fb = db.get(filledBuckets, ts, t2)
@@ -709,17 +719,19 @@ class Beam(Impedance, Power, Plot):
             if np.sum(std[i]) != 0:
                 break
             i = i - 1
+        self.beamDate = time.strftime("%Y-%m-%d %H:%M:%S.SSS",
+            time.localtime(timeStamps[i])).replace("SSS",
+            "%03d" % ((timeStamps[i]-np.floor(timeStamps[i]))*1000))
         if self.verbose:
-            print("Date of the loaded data:", pytimber.dumpdate(timeStamps[i]))
+            print("Date of the loaded data:", self.beamDate)
         std = std[i]
 
-        self.beamDate = pytimber.dumpdate(timeStamps[i])
         self._bunchLength = np.zeros(len(std))
         self.phi = np.zeros(len(std))
         FB = np.zeros(len(fb))
 
         for j in range(len(fb)):
-            good = isinstance(fb[j], (float))
+            good = isinstance(fb[j], (np.int32))
             if good and fb[j] != 0:
                 FB[j] = int((fb[j] - 1) / 10)
             else:
@@ -727,8 +739,8 @@ class Beam(Impedance, Power, Plot):
 
         for j in range(
             len(std)
-        ):  # std is a sorted vector where std[i[j]] rappresent the correct position in the time flow
-            stdIsGood = isinstance(std[j], (float))
+        ):  # std is a sorted vector where std[i[j]] represent the correct position in the time flow
+            stdIsGood = isinstance(std[j], (np.float32))
             if (stdIsGood) and (FB[j] != -1) and (FB[j] < self.M):
                 self._bunchLength[int(FB[j])] = std[j] / 4
                 self._fillingScheme[int(FB[j])] = True
@@ -740,7 +752,7 @@ class Beam(Impedance, Power, Plot):
             print(f"Min. bunch length off all bunches: {np.min(self._bunchLength)}")
 
         self.phi = self.phi[0 : self.M]
-        self.setNpFromFillNumber()
+        self.setNpFromFillNumber(spark=spark)
         self._setBunches()
 
     def setCustomBeam(self):
@@ -849,7 +861,7 @@ class Beam(Impedance, Power, Plot):
 
         self._setBunches()
 
-    def setNpFromFillNumber(self):
+    def setNpFromFillNumber(self, spark=None):
         """Set Intensity from fill number
 
         Retrieves intensity  information from Timber provided a fill Number
@@ -870,7 +882,12 @@ class Beam(Impedance, Power, Plot):
                 "This method uses pytimber. Please follow the installation guide to set it in your python environment"
             )
 
-        db = pytimber.LoggingDB()
+        if spark is not None:
+            db = pytimber.LoggingDB(spark_session=spark)
+        else:
+            # without spark, the older version of pytimber may still work
+            db = pytimber.LoggingDB()
+
         bunchIntensities = (
             "LHC.BCTFR.A6R4.B" + str(self._beamNumber) + ":BUNCH_INTENSITY"
         )
@@ -897,7 +914,9 @@ class Beam(Impedance, Power, Plot):
         self._NpIsComputed = True
         if self.verbose:
             print("Np updated: ", self.Np / 1e11, "e11")
-            print("Np calculated at: ", pytimber.dumpdate(t2))
+            print("Np calculated at: ", time.strftime(
+                "%Y-%m-%d %H:%M:%S.SSS",time.localtime(t2)).replace(
+                "SSS","%03d" % ((t2-np.floor(t2))*1000)))
 
     def setBeamsFromSumWithShift(self, beam1, beam2, shift):
         """Set beam object from the sum of two beam objects

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -61,7 +61,7 @@ ldb.get(ldb.search('LHC%BEAM_ENERGY%')[0], t1='2022-06-15 15:10:30.0000')
 ```
 
 ## Guide to use BIHC on SWAN
-> Guide to perform `bihc` calculations on CERN's SWAN notebook platform: https://swan-k8s.cern.ch
+> Guide to perform `bihc` calculations on CERN's SWAN notebook platform: https://swan.cern.ch
 
 ![swan logo](img/SWAN_0.png)
 
@@ -71,7 +71,7 @@ The recommended setup is 4 cores 16 Gb to speed up calculations. Remember to che
 ![swan environment configuration](img/SWAN_env.png)
 
 #### :warning: Accessing accelerator data from Timber
-If one needs to access data from Timber, the correct Software stack would be `105a NXCALS PRO` that comes with `pytimber` pre-installed and has the SPARK environment mounted.
+If one needs to access data from Timber, the correct Software stack would be `106a NXCALS PRO` that comes with `pytimber` pre-installed and has the SPARK environment mounted.
 
 ### Open the project
 Select the project folder to open:
@@ -93,3 +93,7 @@ Another option is to open a terminal:
 ![swan open terminal button](img/SWAN_terminal.png)
 
 This will give you access to the linux terminal of your kernel environment. There one can simple write `pip install bihc` to install the package and also access the files and python from the terminal.
+
+### Connect to a spark session
+As of pytimber v4.x.x.x, one needs to create a `spark` session. After opening the notebook, click on the star at the top (3rd symbol from the right) to configure and connect to a spark session (see also [here](https://confluence.cern.ch/pages/viewpage.action?pageId=413119283&spaceKey=PYT&title=New%2BPyTimber%2B4.x.x.x%2Binstallation)).
+This will create the `spark` variable (note that it may take some time).

--- a/examples/TimberFillingScheme/Timber_filling_scheme.ipynb
+++ b/examples/TimberFillingScheme/Timber_filling_scheme.ipynb
@@ -75,6 +75,7 @@
     "    spectrum=\"numeric\",\n",
     "    fmax=2e9,\n",
     "    verbose=False,\n",
+    "    spark=spark,\n",
     ")\n",
     "\n",
     "# Exporting frequency array, needed for the impedance curve\n",

--- a/tests/test_002_beam_unit.py
+++ b/tests/test_002_beam_unit.py
@@ -7,8 +7,6 @@
 import numpy as np
 import pytest
 from scipy.constants import e as qe
-from scipy.integrate import trapz
-
 from bihc.beam import Beam
 
 
@@ -37,7 +35,7 @@ def test_beam_custom_scheme_sets_profiles_and_charge():
 
     t, profile = beam.longitudinalProfile
     assert t.shape == profile.shape
-    area = trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
+    area = np.trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
     assert area > 0
 
 

--- a/tests/test_002_beam_unit.py
+++ b/tests/test_002_beam_unit.py
@@ -7,6 +7,7 @@
 import numpy as np
 import pytest
 from scipy.constants import e as qe
+from scipy.integrate import trapz
 
 from bihc.beam import Beam
 
@@ -36,7 +37,7 @@ def test_beam_custom_scheme_sets_profiles_and_charge():
 
     t, profile = beam.longitudinalProfile
     assert t.shape == profile.shape
-    area = np.trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
+    area = trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
     assert area > 0
 
 

--- a/tests/test_002_beam_unit.py
+++ b/tests/test_002_beam_unit.py
@@ -36,7 +36,7 @@ def test_beam_custom_scheme_sets_profiles_and_charge():
 
     t, profile = beam.longitudinalProfile
     assert t.shape == profile.shape
-    area = np.trapezoid(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
+    area = np.trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
     assert area > 0
 
 

--- a/tests/test_002_beam_unit.py
+++ b/tests/test_002_beam_unit.py
@@ -7,6 +7,12 @@
 import numpy as np
 import pytest
 from scipy.constants import e as qe
+try:
+    from scipy.integrate import trapezoid
+except ImportError:
+    from scipy.integrate import trapz as trapezoid
+    print("[!] Using deprecated trapz function from scipy.integrate. Please update your scipy version.")
+
 from bihc.beam import Beam
 
 
@@ -35,7 +41,7 @@ def test_beam_custom_scheme_sets_profiles_and_charge():
 
     t, profile = beam.longitudinalProfile
     assert t.shape == profile.shape
-    area = np.trapz(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
+    area = trapezoid(beam.profile_1_bunch[1], beam.profile_1_bunch[0])
     assert area > 0
 
 


### PR DESCRIPTION
## 📝 Pull Request Summary
The newest pytimber 4.x.x.x could not be used - the corresponding example would fail under SWAN. The main reason is the need for a spark session to be used as input to the code.
A few typos as well as one test (not strictly related to the PR) were fixed in the process.

## 🔧 Changes Made
- Define a spark session as input of the `Beam` class (default value = `None`). The variable is created automatically under SWAN when connecting to a spark session.
- Correct the corresponding example (`examples/TimberFillingScheme/Timber_filling_scheme.ipynb`)
- Update the documentation for SWAN usage with pytimber
- Fixing a few problems with the new pytimber (absence of the method `pytimber.dumpdate`, correcting the type of some array elements)
- No test added (pytimber cannot be tested easily - a SWAN session is needed)
- Fixing an obsolete use of `numpy.trapezoid` method in one test - now replaced by the corresponding `trapz` from `scipy.integrate` (this is unrelated to `pytimber`, but needed)
- Some typos fixed in docstrings

## ✅ Checklist
- [✅ ] Code follows the project's style and guidelines
- [N/A ] Added tests for new functionality
- [✅ ] Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`)
- [✅ ] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs
Closes #15
